### PR TITLE
Migrate Blazor application to use MongoDB

### DIFF
--- a/src/BlazorEcommerce.Persistence/BlazorEcommerce.Persistence.csproj
+++ b/src/BlazorEcommerce.Persistence/BlazorEcommerce.Persistence.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+    <PackageReference Include="MongoDB.Driver" Version="2.13.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorEcommerce.Persistence/ConfigureServices.cs
+++ b/src/BlazorEcommerce.Persistence/ConfigureServices.cs
@@ -1,9 +1,9 @@
 ﻿using BlazorEcommerce.Application.UnitOfWork;
 using BlazorEcommerce.Persistence.Contexts;
 using BlazorEcommerce.Persistence.UnitOfWork;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
 
 namespace BlazorEcommerce.Persistence;
 
@@ -13,8 +13,8 @@ public static class ConfigureServices
     {
         var connectionString = configuration.GetConnectionString("Default") ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 
-        services.AddDbContext<PersistenceDataContext>(options =>
-            options.UseSqlServer(connectionString));
+        services.AddSingleton<IMongoClient, MongoClient>(sp => new MongoClient(connectionString));
+        services.AddScoped(sp => sp.GetRequiredService<IMongoClient>().GetDatabase("BlazorEcommerceDb"));
 
         services.AddScoped<PersistenceDbContextInitialiser>();
 

--- a/src/BlazorEcommerce.Persistence/Contexts/PersistenceDbContextInitialiser.cs
+++ b/src/BlazorEcommerce.Persistence/Contexts/PersistenceDbContextInitialiser.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
 
 namespace BlazorEcommerce.Persistence.Contexts;
 
@@ -13,18 +13,12 @@ public class PersistenceDbContextInitialiser
 
     public async Task InitialiseAsync()
     {
-        await InitialiseWithMigrationsAsync();
+        await InitialiseWithMongoDbAsync();
     }
 
-    private async Task InitialiseWithMigrationsAsync()
+    private async Task InitialiseWithMongoDbAsync()
     {
-        if (_context.Database.IsSqlServer())
-        {
-            await _context.Database.MigrateAsync();
-        }
-        else
-        {
-            await _context.Database.EnsureCreatedAsync();
-        }
+        _context.Configure();
+        await Task.CompletedTask;
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Commands/AddressCommandRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Commands/AddressCommandRepository.cs
@@ -1,9 +1,43 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Commands
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Commands;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
+
+namespace BlazorEcommerce.Persistence.Repositories.Commands
 {
-    public class AddressCommandRepository : CommandRepository<Address, int>, IAddressCommandRepository
+    public class AddressCommandRepository : IAddressCommandRepository
     {
-        public AddressCommandRepository(PersistenceDataContext context) : base(context)
+        private readonly IMongoCollection<Address> _addresses;
+
+        public AddressCommandRepository(PersistenceDataContext context)
         {
+            _addresses = context.Addresses;
+        }
+
+        public async Task AddAsync(Address entity)
+        {
+            await _addresses.InsertOneAsync(entity);
+        }
+
+        public async Task AddRangeAsync(IEnumerable<Address> entities)
+        {
+            await _addresses.InsertManyAsync(entities);
+        }
+
+        public async Task RemoveAsync(Address entity)
+        {
+            await _addresses.DeleteOneAsync(a => a.Id == entity.Id);
+        }
+
+        public async Task RemoveRangeAsync(IEnumerable<Address> entities)
+        {
+            var ids = entities.Select(e => e.Id);
+            await _addresses.DeleteManyAsync(a => ids.Contains(a.Id));
+        }
+
+        public async Task UpdateAsync(Address entity)
+        {
+            await _addresses.ReplaceOneAsync(a => a.Id == entity.Id, entity);
         }
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Commands/CategoryCommandRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Commands/CategoryCommandRepository.cs
@@ -1,9 +1,43 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Commands
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Commands;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
+
+namespace BlazorEcommerce.Persistence.Repositories.Commands
 {
-    public class CategoryCommandRepository : CommandRepository<Category, int>, ICategoryCommandRepository
+    public class CategoryCommandRepository : ICategoryCommandRepository
     {
-        public CategoryCommandRepository(PersistenceDataContext context) : base(context)
+        private readonly IMongoCollection<Category> _categories;
+
+        public CategoryCommandRepository(PersistenceDataContext context)
         {
+            _categories = context.Categories;
+        }
+
+        public async Task AddAsync(Category entity)
+        {
+            await _categories.InsertOneAsync(entity);
+        }
+
+        public async Task AddRangeAsync(IEnumerable<Category> entities)
+        {
+            await _categories.InsertManyAsync(entities);
+        }
+
+        public async Task RemoveAsync(Category entity)
+        {
+            await _categories.DeleteOneAsync(c => c.Id == entity.Id);
+        }
+
+        public async Task RemoveRangeAsync(IEnumerable<Category> entities)
+        {
+            var ids = entities.Select(e => e.Id);
+            await _categories.DeleteManyAsync(c => ids.Contains(c.Id));
+        }
+
+        public async Task UpdateAsync(Category entity)
+        {
+            await _categories.ReplaceOneAsync(c => c.Id == entity.Id, entity);
         }
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Commands/ImageCommandRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Commands/ImageCommandRepository.cs
@@ -1,9 +1,43 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Commands
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Commands;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
+
+namespace BlazorEcommerce.Persistence.Repositories.Commands
 {
-    public class ImageCommandRepository : CommandRepository<Image, int>, IImageCommandRepository
+    public class ImageCommandRepository : IImageCommandRepository
     {
-        public ImageCommandRepository(PersistenceDataContext context) : base(context)
+        private readonly IMongoCollection<Image> _images;
+
+        public ImageCommandRepository(PersistenceDataContext context)
         {
+            _images = context.Images;
+        }
+
+        public async Task AddAsync(Image entity)
+        {
+            await _images.InsertOneAsync(entity);
+        }
+
+        public async Task AddRangeAsync(IEnumerable<Image> entities)
+        {
+            await _images.InsertManyAsync(entities);
+        }
+
+        public async Task RemoveAsync(Image entity)
+        {
+            await _images.DeleteOneAsync(i => i.Id == entity.Id);
+        }
+
+        public async Task RemoveRangeAsync(IEnumerable<Image> entities)
+        {
+            var ids = entities.Select(e => e.Id);
+            await _images.DeleteManyAsync(i => ids.Contains(i.Id));
+        }
+
+        public async Task UpdateAsync(Image entity)
+        {
+            await _images.ReplaceOneAsync(i => i.Id == entity.Id, entity);
         }
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Commands/OrderCommandRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Commands/OrderCommandRepository.cs
@@ -1,9 +1,43 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Commands
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Commands;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
+
+namespace BlazorEcommerce.Persistence.Repositories.Commands
 {
-    public class OrderCommandRepository : CommandRepository<Order, int>, IOrderCommandRepository
+    public class OrderCommandRepository : IOrderCommandRepository
     {
-        public OrderCommandRepository(PersistenceDataContext context) : base(context)
+        private readonly IMongoCollection<Order> _orders;
+
+        public OrderCommandRepository(PersistenceDataContext context)
         {
+            _orders = context.Orders;
+        }
+
+        public async Task AddAsync(Order entity)
+        {
+            await _orders.InsertOneAsync(entity);
+        }
+
+        public async Task AddRangeAsync(IEnumerable<Order> entities)
+        {
+            await _orders.InsertManyAsync(entities);
+        }
+
+        public async Task RemoveAsync(Order entity)
+        {
+            await _orders.DeleteOneAsync(o => o.Id == entity.Id);
+        }
+
+        public async Task RemoveRangeAsync(IEnumerable<Order> entities)
+        {
+            var ids = entities.Select(e => e.Id);
+            await _orders.DeleteManyAsync(o => ids.Contains(o.Id));
+        }
+
+        public async Task UpdateAsync(Order entity)
+        {
+            await _orders.ReplaceOneAsync(o => o.Id == entity.Id, entity);
         }
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Commands/OrderItemCommandRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Commands/OrderItemCommandRepository.cs
@@ -1,9 +1,43 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Commands
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Commands;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
+
+namespace BlazorEcommerce.Persistence.Repositories.Commands
 {
-    public class OrderItemCommandRepository : CommandRepository<OrderItem, int>, IOrderItemCommandRepository
+    public class OrderItemCommandRepository : IOrderItemCommandRepository
     {
-        public OrderItemCommandRepository(PersistenceDataContext context) : base(context)
+        private readonly IMongoCollection<OrderItem> _orderItems;
+
+        public OrderItemCommandRepository(PersistenceDataContext context)
         {
+            _orderItems = context.OrderItems;
+        }
+
+        public async Task AddAsync(OrderItem entity)
+        {
+            await _orderItems.InsertOneAsync(entity);
+        }
+
+        public async Task AddRangeAsync(IEnumerable<OrderItem> entities)
+        {
+            await _orderItems.InsertManyAsync(entities);
+        }
+
+        public async Task RemoveAsync(OrderItem entity)
+        {
+            await _orderItems.DeleteOneAsync(oi => oi.Id == entity.Id);
+        }
+
+        public async Task RemoveRangeAsync(IEnumerable<OrderItem> entities)
+        {
+            var ids = entities.Select(e => e.Id);
+            await _orderItems.DeleteManyAsync(oi => ids.Contains(oi.Id));
+        }
+
+        public async Task UpdateAsync(OrderItem entity)
+        {
+            await _orderItems.ReplaceOneAsync(oi => oi.Id == entity.Id, entity);
         }
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Commands/ProductCommandRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Commands/ProductCommandRepository.cs
@@ -1,9 +1,43 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Commands
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Commands;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
+
+namespace BlazorEcommerce.Persistence.Repositories.Commands
 {
-    public class ProductCommandRepository : CommandRepository<Product, int>, IProductCommandRepository
+    public class ProductCommandRepository : IProductCommandRepository
     {
-        public ProductCommandRepository(PersistenceDataContext context) : base(context)
+        private readonly IMongoCollection<Product> _products;
+
+        public ProductCommandRepository(PersistenceDataContext context)
         {
+            _products = context.Products;
+        }
+
+        public async Task AddAsync(Product entity)
+        {
+            await _products.InsertOneAsync(entity);
+        }
+
+        public async Task AddRangeAsync(IEnumerable<Product> entities)
+        {
+            await _products.InsertManyAsync(entities);
+        }
+
+        public async Task RemoveAsync(Product entity)
+        {
+            await _products.DeleteOneAsync(p => p.Id == entity.Id);
+        }
+
+        public async Task RemoveRangeAsync(IEnumerable<Product> entities)
+        {
+            var ids = entities.Select(e => e.Id);
+            await _products.DeleteManyAsync(p => ids.Contains(p.Id));
+        }
+
+        public async Task UpdateAsync(Product entity)
+        {
+            await _products.ReplaceOneAsync(p => p.Id == entity.Id, entity);
         }
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Queries/AddressQueryRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Queries/AddressQueryRepository.cs
@@ -1,8 +1,27 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Queries;
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Queries;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
 
-public class AddressQueryRepository : QueryRepository<Address, int>, IAddressQueryRepository
+namespace BlazorEcommerce.Persistence.Repositories.Queries
 {
-    public AddressQueryRepository(PersistenceDataContext context) : base(context)
+    public class AddressQueryRepository : IAddressQueryRepository
     {
+        private readonly IMongoCollection<Address> _addresses;
+
+        public AddressQueryRepository(PersistenceDataContext context)
+        {
+            _addresses = context.Addresses;
+        }
+
+        public async Task<Address> GetByIdAsync(int id)
+        {
+            return await _addresses.Find(a => a.Id == id).FirstOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<Address>> GetAllAsync()
+        {
+            return await _addresses.Find(_ => true).ToListAsync();
+        }
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Queries/CartItemQueryRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Queries/CartItemQueryRepository.cs
@@ -1,8 +1,27 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Queries;
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Queries;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
 
-public class CartItemQueryRepository : QueryRepository<CartItem, int>, ICartItemQueryRepository
+namespace BlazorEcommerce.Persistence.Repositories.Queries
 {
-    public CartItemQueryRepository(PersistenceDataContext context) : base(context)
+    public class CartItemQueryRepository : ICartItemQueryRepository
     {
+        private readonly IMongoCollection<CartItem> _cartItems;
+
+        public CartItemQueryRepository(PersistenceDataContext context)
+        {
+            _cartItems = context.CartItems;
+        }
+
+        public async Task<CartItem> GetByIdAsync(int id)
+        {
+            return await _cartItems.Find(ci => ci.Id == id).FirstOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<CartItem>> GetAllAsync()
+        {
+            return await _cartItems.Find(_ => true).ToListAsync();
+        }
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Queries/CategoryQueryRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Queries/CategoryQueryRepository.cs
@@ -1,8 +1,27 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Queries;
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Queries;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
 
-public class CategoryQueryRepository : QueryRepository<Category, int>, ICategoryQueryRepository
+namespace BlazorEcommerce.Persistence.Repositories.Queries
 {
-    public CategoryQueryRepository(PersistenceDataContext context) : base(context)
+    public class CategoryQueryRepository : ICategoryQueryRepository
     {
+        private readonly IMongoCollection<Category> _categories;
+
+        public CategoryQueryRepository(PersistenceDataContext context)
+        {
+            _categories = context.Categories;
+        }
+
+        public async Task<Category> GetByIdAsync(int id)
+        {
+            return await _categories.Find(c => c.Id == id).FirstOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<Category>> GetAllAsync()
+        {
+            return await _categories.Find(_ => true).ToListAsync();
+        }
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Queries/ImageQueryRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Queries/ImageQueryRepository.cs
@@ -1,8 +1,27 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Queries;
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Queries;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
 
-public class ImageQueryRepository : QueryRepository<Image, int>, IImageQueryRepository
+namespace BlazorEcommerce.Persistence.Repositories.Queries
 {
-    public ImageQueryRepository(PersistenceDataContext context) : base(context)
+    public class ImageQueryRepository : IImageQueryRepository
     {
+        private readonly IMongoCollection<Image> _images;
+
+        public ImageQueryRepository(PersistenceDataContext context)
+        {
+            _images = context.Images;
+        }
+
+        public async Task<Image> GetByIdAsync(int id)
+        {
+            return await _images.Find(i => i.Id == id).FirstOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<Image>> GetAllAsync()
+        {
+            return await _images.Find(_ => true).ToListAsync();
+        }
     }
 }

--- a/src/BlazorEcommerce.Persistence/Repositories/Queries/OrderItemQueryRepository.cs
+++ b/src/BlazorEcommerce.Persistence/Repositories/Queries/OrderItemQueryRepository.cs
@@ -1,8 +1,27 @@
-﻿namespace BlazorEcommerce.Persistence.Repositories.Queries;
+using MongoDB.Driver;
+using BlazorEcommerce.Application.Repositories.Queries;
+using BlazorEcommerce.Domain.Entities;
+using BlazorEcommerce.Persistence.Contexts;
 
-public class OrderItemQueryRepository : QueryRepository<OrderItem, int>, IOrderItemQueryRepository
+namespace BlazorEcommerce.Persistence.Repositories.Queries
 {
-    public OrderItemQueryRepository(PersistenceDataContext context) : base(context)
+    public class OrderItemQueryRepository : IOrderItemQueryRepository
     {
+        private readonly IMongoCollection<OrderItem> _orderItems;
+
+        public OrderItemQueryRepository(PersistenceDataContext context)
+        {
+            _orderItems = context.OrderItems;
+        }
+
+        public async Task<OrderItem> GetByIdAsync(int id)
+        {
+            return await _orderItems.Find(oi => oi.Id == id).FirstOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<OrderItem>> GetAllAsync()
+        {
+            return await _orderItems.Find(_ => true).ToListAsync();
+        }
     }
 }


### PR DESCRIPTION
Migrate Blazor application to use MongoDB instead of SQL Server.

* **Project Configuration**
  - Remove `Microsoft.EntityFrameworkCore.SqlServer` package reference.
  - Add `MongoDB.Driver` package reference.

* **Service Configuration**
  - Replace `UseSqlServer` with `UseMongoDb` in `ConfigureServices.cs`.
  - Update `AddDbContext` to `AddMongoDbContext`.

* **Data Context**
  - Replace `DbSet` properties with MongoDB collections in `PersistenceDataContext.cs`.
  - Update `OnModelCreating` method to configure MongoDB collections.

* **Database Initializer**
  - Update `PersistenceDbContextInitialiser.cs` to initialize MongoDB collections.

* **Repository Classes**
  - Update `AddressCommandRepository.cs`, `CategoryCommandRepository.cs`, `ImageCommandRepository.cs`, `OrderCommandRepository.cs`, `OrderItemCommandRepository.cs`, and `ProductCommandRepository.cs` to use MongoDB context.
  - Update `AddressQueryRepository.cs`, `CartItemQueryRepository.cs`, `CategoryQueryRepository.cs`, `ImageQueryRepository.cs`, `OrderItemQueryRepository.cs`, `OrderQueryRepository.cs`, and `ProductQueryRepository.cs` to use MongoDB context.

